### PR TITLE
feat: add sequence diagram designer

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,9 +1,11 @@
 import { Routes } from '@angular/router';
 import { MenuBuilderPage } from './pages/menu-builder/menu-builder.page';
 import { RazorEditorPage } from './pages/razor-editor/razor-editor.page';
+import { SequenceDesignerPage } from './pages/sequence-designer/sequence-designer.page';
 
 export const routes: Routes = [
   { path: 'menu-builder', component: MenuBuilderPage },
   { path: 'razor-editor', component: RazorEditorPage },
+  { path: 'sequence-designer', component: SequenceDesignerPage },
   { path: '', redirectTo: '/menu-builder', pathMatch: 'full' }
 ];

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -31,19 +31,27 @@ export class App {
       order: 1
     },
     {
+      id: 'sequence-designer',
+      label: 'Sequence Designer',
+      route: '/sequence-designer',
+      icon: 'bi-diagram-3',
+      isActive: false,
+      order: 2
+    },
+    {
       id: 'dashboard',
       label: 'Dashboard',
       route: '/dashboard',
       icon: 'bi-speedometer2',
       isActive: false,
-      order: 2
+      order: 3
     },
     {
       id: 'users',
       label: 'User Management',
       icon: 'bi-people',
       isExpanded: false,
-      order: 3,
+      order: 4,
       children: [
         {
           id: 'users-list',
@@ -74,7 +82,7 @@ export class App {
       label: 'Products',
       icon: 'bi-box-seam',
       isExpanded: false,
-      order: 4,
+      order: 5,
       children: [
         {
           id: 'products-list',
@@ -105,7 +113,7 @@ export class App {
       label: 'Orders',
       route: '/orders',
       icon: 'bi-cart',
-      order: 5,
+      order: 6,
       badge: {
         text: '5',
         color: 'danger'
@@ -115,7 +123,7 @@ export class App {
       id: 'reports',
       label: 'Analytics & Reports',
       icon: 'bi-graph-up',
-      order: 6,
+      order: 7,
       children: [
         {
           id: 'reports-sales',
@@ -136,7 +144,7 @@ export class App {
       label: 'Settings',
       route: '/settings',
       icon: 'bi-gear',
-      order: 7
+      order: 8
     }
   ];
 

--- a/src/app/components/sequence-diagram-designer/sequence-diagram-designer.component.html
+++ b/src/app/components/sequence-diagram-designer/sequence-diagram-designer.component.html
@@ -1,0 +1,209 @@
+<div class="designer-container">
+  <div class="toolbar">
+    <button type="button" class="btn btn-primary btn-sm" (click)="addPhase()">
+      <i class="bi bi-plus-circle me-1"></i>
+      Add phase
+    </button>
+    <button
+      type="button"
+      class="btn btn-outline-primary btn-sm"
+      (click)="addParallelPhase()"
+      [disabled]="selectedNode()?.type !== 'phase'"
+    >
+      <i class="bi bi-diagram-3 me-1"></i>
+      Add parallel phase
+    </button>
+    <button
+      type="button"
+      class="btn btn-outline-danger btn-sm"
+      (click)="deleteSelected()"
+      [disabled]="!selectedNode()"
+    >
+      <i class="bi bi-trash me-1"></i>
+      Delete selected
+    </button>
+    <div class="toolbar-spacer"></div>
+    <button type="button" class="btn btn-success btn-sm" (click)="downloadJson()">
+      <i class="bi bi-download me-1"></i>
+      Export JSON
+    </button>
+  </div>
+
+  <div class="designer-body">
+    <div class="diagram-panel">
+      <svg
+        class="diagram-canvas"
+        [attr.width]="diagramWidth()"
+        [attr.height]="diagramHeight()"
+        role="img"
+        aria-label="Lifecycle sequence diagram"
+      >
+        <defs>
+          <marker
+            id="arrow"
+            viewBox="0 0 10 10"
+            refX="8"
+            refY="5"
+            markerWidth="6"
+            markerHeight="6"
+            orient="auto-start-reverse"
+          >
+            <path d="M 0 0 L 10 5 L 0 10 z" class="arrow-head"></path>
+          </marker>
+        </defs>
+
+        <circle class="start-node" [attr.cx]="startX - 30" [attr.cy]="mainPhaseY + phaseHeight / 2" r="24"></circle>
+        <text
+          class="node-label"
+          [attr.x]="startX - 30"
+          [attr.y]="mainPhaseY + phaseHeight / 2 + 4"
+        >
+          Start
+        </text>
+
+        <line
+          *ngIf="phaseLayout().length > 0"
+          class="connector"
+          [attr.x1]="startX - 6"
+          [attr.y1]="mainPhaseY + phaseHeight / 2"
+          [attr.x2]="phaseLayout()[0].x - 10"
+          [attr.y2]="mainPhaseY + phaseHeight / 2"
+          marker-end="url(#arrow)"
+        ></line>
+
+        <ng-container *ngFor="let phase of phaseLayout(); let i = index; trackBy: trackPhase">
+          <g
+            class="phase-node"
+            [class.is-selected]="isPhaseSelected(phase.data.id)"
+            (click)="selectPhase(phase.data.id)"
+          >
+            <rect
+              [attr.x]="phase.x"
+              [attr.y]="phase.y"
+              [attr.width]="phase.width"
+              [attr.height]="phase.height"
+              rx="12"
+              ry="12"
+            ></rect>
+            <text class="phase-name" [attr.x]="phase.x + phase.width / 2" [attr.y]="phase.y + 32">
+              {{ phase.data.name }}
+            </text>
+            <text class="phase-type" [attr.x]="phase.x + phase.width / 2" [attr.y]="phase.y + phase.height - 16">
+              Phase
+            </text>
+          </g>
+
+          <line
+            *ngIf="i < phaseLayout().length - 1"
+            class="connector"
+            [attr.x1]="phase.x + phase.width"
+            [attr.y1]="phase.y + phase.height / 2"
+            [attr.x2]="phaseLayout()[i + 1].x - 10"
+            [attr.y2]="phaseLayout()[i + 1].y + phaseLayout()[i + 1].height / 2"
+            marker-end="url(#arrow)"
+          ></line>
+
+          <ng-container *ngFor="let subPhase of phase.subPhases; trackBy: trackSubPhase">
+            <path
+              class="connector"
+              [attr.d]="
+                'M ' + (phase.x + phase.width / 2) + ' ' + (phase.y + phase.height) +
+                ' V ' + (subPhase.y - 20) +
+                ' Q ' + (phase.x + phase.width / 2) + ' ' + (subPhase.y - 10) + ', ' +
+                (subPhase.x + subPhase.width / 2) + ' ' + (subPhase.y - 10) +
+                ' V ' + subPhase.y
+              "
+              marker-end="url(#arrow)"
+            ></path>
+
+            <g
+              class="phase-node parallel"
+              [class.is-selected]="isSubPhaseSelected(phase.data.id, subPhase.data.id)"
+              (click)="selectSubPhase(phase.data.id, subPhase.data.id); $event.stopPropagation()"
+            >
+              <rect
+                [attr.x]="subPhase.x"
+                [attr.y]="subPhase.y"
+                [attr.width]="subPhase.width"
+                [attr.height]="subPhase.height"
+                rx="10"
+                ry="10"
+              ></rect>
+              <text class="phase-name" [attr.x]="subPhase.x + subPhase.width / 2" [attr.y]="subPhase.y + 26">
+                {{ subPhase.data.name }}
+              </text>
+              <text class="phase-type" [attr.x]="subPhase.x + subPhase.width / 2" [attr.y]="subPhase.y + subPhase.height - 14">
+                Parallel
+              </text>
+            </g>
+
+            <line
+              *ngIf="getEndPosition(subPhase.data.targetEnd) as end"
+              class="connector dashed"
+              [attr.x1]="subPhase.x + subPhase.width"
+              [attr.y1]="subPhase.y + subPhase.height / 2"
+              [attr.x2]="end.x - endRadius"
+              [attr.y2]="end.y"
+              marker-end="url(#arrow)"
+            ></line>
+          </ng-container>
+
+          <line
+            *ngIf="getEndPosition(phase.data.targetEnd) as end"
+            class="connector dashed"
+            [attr.x1]="phase.x + phase.width"
+            [attr.y1]="phase.y + phase.height / 2"
+            [attr.x2]="end.x - endRadius"
+            [attr.y2]="end.y"
+            marker-end="url(#arrow)"
+          ></line>
+        </ng-container>
+
+        <ng-container *ngFor="let end of endPositions()">
+          <circle class="end-node" [attr.cx]="end.x" [attr.cy]="end.y" [attr.r]="endRadius"></circle>
+          <text class="node-label" [attr.x]="end.x" [attr.y]="end.y + 4">{{ end.label }}</text>
+        </ng-container>
+      </svg>
+    </div>
+
+    <div class="properties-panel">
+      <h5 class="panel-title">Inspector</h5>
+      <ng-container *ngIf="selectedNode(); else noSelection">
+        <div class="mb-3">
+          <label class="form-label">Name</label>
+          <input
+            type="text"
+            class="form-control form-control-sm"
+            [ngModel]="selectedName"
+            (ngModelChange)="updateSelectedName($event)"
+          />
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Type</label>
+          <div class="form-control form-control-sm readonly">{{ selectedTypeLabel }}</div>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Converges to</label>
+          <select
+            class="form-select form-select-sm"
+            [ngModel]="selectedTargetEnd"
+            (ngModelChange)="updateSelectedEnd($event)"
+          >
+            <option *ngFor="let end of endNodes" [ngValue]="end.id">{{ end.label }}</option>
+          </select>
+        </div>
+        <div class="alert alert-info" role="alert">
+          Parallel phases inherit the sequential context of their parent and must reconnect to one of the end nodes.
+        </div>
+      </ng-container>
+      <ng-template #noSelection>
+        <p class="text-muted mb-0">Select a phase or parallel phase to edit its properties.</p>
+      </ng-template>
+    </div>
+  </div>
+
+  <div class="export-panel">
+    <label class="form-label">JSON structure</label>
+    <textarea class="form-control" rows="10" readonly>{{ exportedJson() }}</textarea>
+  </div>
+</div>

--- a/src/app/components/sequence-diagram-designer/sequence-diagram-designer.component.scss
+++ b/src/app/components/sequence-diagram-designer/sequence-diagram-designer.component.scss
@@ -1,0 +1,153 @@
+.designer-container {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+
+  .toolbar-spacer {
+    flex: 1;
+  }
+}
+
+.designer-body {
+  display: flex;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.diagram-panel {
+  flex: 1 1 60%;
+  min-width: 320px;
+  background: #f8f9fa;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 0.75rem;
+  padding: 1rem;
+  overflow: auto;
+}
+
+.diagram-canvas {
+  width: 100%;
+  height: auto;
+}
+
+.arrow-head {
+  fill: #6c757d;
+}
+
+.connector {
+  stroke: #6c757d;
+  stroke-width: 2;
+  fill: none;
+}
+
+.connector.dashed {
+  stroke-dasharray: 6 4;
+}
+
+.phase-node {
+  cursor: pointer;
+  transition: transform 0.15s ease-in-out;
+
+  rect {
+    fill: #ffffff;
+    stroke: #0d6efd;
+    stroke-width: 2;
+  }
+
+  &.parallel rect {
+    stroke: #6610f2;
+  }
+
+  &.is-selected rect {
+    fill: rgba(13, 110, 253, 0.12);
+  }
+
+  &:hover rect {
+    filter: drop-shadow(0 0 6px rgba(13, 110, 253, 0.4));
+  }
+}
+
+.phase-name,
+.phase-type,
+.node-label {
+  font-family: 'Inter', 'Segoe UI', sans-serif;
+  text-anchor: middle;
+  fill: #212529;
+}
+
+.phase-name {
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.phase-type {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  fill: #6c757d;
+}
+
+.start-node {
+  fill: #198754;
+  stroke: #0f5132;
+  stroke-width: 2;
+}
+
+.end-node {
+  fill: #dc3545;
+  stroke: #842029;
+  stroke-width: 2;
+}
+
+.node-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  fill: #343a40;
+}
+
+.properties-panel {
+  flex: 1 1 280px;
+  min-width: 260px;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 0.75rem;
+  padding: 1rem 1.25rem;
+  background: #ffffff;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+}
+
+.panel-title {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+}
+
+.form-control.readonly {
+  background-color: #f8f9fa;
+}
+
+.export-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+textarea.form-control {
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-size: 0.85rem;
+  min-height: 200px;
+}
+
+@media (max-width: 992px) {
+  .diagram-panel {
+    flex: 1 1 100%;
+  }
+
+  .properties-panel {
+    flex: 1 1 100%;
+  }
+}

--- a/src/app/components/sequence-diagram-designer/sequence-diagram-designer.component.ts
+++ b/src/app/components/sequence-diagram-designer/sequence-diagram-designer.component.ts
@@ -1,0 +1,373 @@
+import { Component, computed, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import {
+  ApplicationLifecyclePhaseDto,
+  ApplicationLifecycleSubPhaseDto,
+  ApplicationLifecycleState,
+} from '../../models/application-lifecycle-phase.dto';
+
+type SequenceNodeType = 'phase' | 'parallel';
+
+type SelectedNode =
+  | { type: 'phase'; phaseId: string }
+  | { type: 'subPhase'; phaseId: string; subPhaseId: string };
+
+interface SequenceSubPhase extends ApplicationLifecycleSubPhaseDto {
+  nodeType: Extract<SequenceNodeType, 'parallel'>;
+  targetEnd: number;
+}
+
+interface SequencePhase extends ApplicationLifecyclePhaseDto {
+  nodeType: Extract<SequenceNodeType, 'phase'>;
+  targetEnd: number;
+  subPhases: SequenceSubPhase[];
+}
+
+interface PhaseLayoutNode {
+  data: SequencePhase;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  subPhases: PhaseLayoutSubNode[];
+}
+
+interface PhaseLayoutSubNode {
+  data: SequenceSubPhase;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+@Component({
+  selector: 'app-sequence-diagram-designer',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './sequence-diagram-designer.component.html',
+  styleUrl: './sequence-diagram-designer.component.scss',
+})
+export class SequenceDiagramDesignerComponent {
+  private nextId = 0;
+
+  readonly startX = 60;
+  readonly mainPhaseY = 160;
+  readonly phaseWidth = 180;
+  readonly phaseHeight = 70;
+  readonly phaseGap = 220;
+  readonly parallelGap = 90;
+  readonly subPhaseHeight = 60;
+  readonly endSpacing = 120;
+  readonly endRadius = 28;
+
+  readonly endNodes = [
+    { id: 1, label: 'End 1' },
+    { id: 2, label: 'End 2' },
+    { id: 3, label: 'End 3' },
+  ];
+
+  readonly phases = signal<SequencePhase[]>([
+    this.createPhase('Phase 1'),
+  ]);
+
+  readonly selectedNode = signal<SelectedNode | null>(null);
+
+  readonly phaseLayout = computed<PhaseLayoutNode[]>(() => {
+    return this.phases().map((phase, index) => {
+      const x = this.startX + index * this.phaseGap;
+      const y = this.mainPhaseY;
+      const subPhases = phase.subPhases.map((subPhase, subIndex) => ({
+        data: subPhase,
+        x,
+        y: this.mainPhaseY + this.phaseHeight + (subIndex + 1) * this.parallelGap,
+        width: this.phaseWidth,
+        height: this.subPhaseHeight,
+      }));
+
+      return {
+        data: phase,
+        x,
+        y,
+        width: this.phaseWidth,
+        height: this.phaseHeight,
+        subPhases,
+      };
+    });
+  });
+
+  readonly diagramWidth = computed(() => {
+    return this.startX + this.phaseGap * this.phases().length + this.phaseWidth + 260;
+  });
+
+  readonly diagramHeight = computed(() => {
+    const baseHeight = this.mainPhaseY + this.phaseHeight + this.parallelGap;
+    const maxSubPhases = this.phases().reduce((max, phase) => Math.max(max, phase.subPhases.length), 0);
+    const subPhaseHeight = baseHeight + maxSubPhases * this.parallelGap;
+    const endSectionHeight = this.mainPhaseY - 60 + (this.endNodes.length - 1) * this.endSpacing + this.endRadius * 2 + 80;
+    return Math.max(subPhaseHeight + 160, endSectionHeight);
+  });
+
+  readonly endPositions = computed(() => {
+    const x = this.diagramWidth() - 100;
+    const startY = this.mainPhaseY - 80;
+
+    return this.endNodes.map((end, index) => ({
+      ...end,
+      x,
+      y: startY + index * this.endSpacing,
+    }));
+  });
+
+  readonly exportedStructure = computed<ApplicationLifecyclePhaseDto[]>(() =>
+    this.phases().map(phase => this.mapPhaseToDto(phase))
+  );
+
+  readonly exportedJson = computed(() => JSON.stringify(this.exportedStructure(), null, 2));
+
+  addPhase(): void {
+    this.phases.update(phases => [...phases, this.createPhase(`Phase ${phases.length + 1}`)]);
+  }
+
+  addParallelPhase(): void {
+    const selected = this.selectedNode();
+    if (!selected || selected.type !== 'phase') {
+      return;
+    }
+
+    const parallelIndex =
+      this.phases().find(p => p.id === selected.phaseId)?.subPhases.length ?? 0;
+
+    this.phases.update(phases =>
+      phases.map(phase =>
+        phase.id === selected.phaseId
+          ? {
+              ...phase,
+              subPhases: [...phase.subPhases, this.createSubPhase(`Parallel ${parallelIndex + 1}`)],
+            }
+          : phase
+      )
+    );
+  }
+
+  deleteSelected(): void {
+    const selected = this.selectedNode();
+    if (!selected) {
+      return;
+    }
+
+    if (selected.type === 'phase') {
+      const updated = this.phases().filter(phase => phase.id !== selected.phaseId);
+      if (updated.length === 0) {
+        this.phases.set([this.createPhase('Phase 1')]);
+      } else {
+        this.phases.set(updated);
+      }
+    } else {
+      this.phases.update(phases =>
+        phases.map(phase =>
+          phase.id === selected.phaseId
+            ? { ...phase, subPhases: phase.subPhases.filter(sub => sub.id !== selected.subPhaseId) }
+            : phase
+        )
+      );
+    }
+
+    this.selectedNode.set(null);
+  }
+
+  selectPhase(phaseId: string): void {
+    this.selectedNode.set({ type: 'phase', phaseId });
+  }
+
+  selectSubPhase(phaseId: string, subPhaseId: string): void {
+    this.selectedNode.set({ type: 'subPhase', phaseId, subPhaseId });
+  }
+
+  isPhaseSelected(phaseId: string): boolean {
+    const selected = this.selectedNode();
+    return selected?.type === 'phase' && selected.phaseId === phaseId;
+  }
+
+  isSubPhaseSelected(phaseId: string, subPhaseId: string): boolean {
+    const selected = this.selectedNode();
+    return selected?.type === 'subPhase' && selected.phaseId === phaseId && selected.subPhaseId === subPhaseId;
+  }
+
+  updateSelectedName(name: string): void {
+    const selected = this.selectedNode();
+    if (!selected) {
+      return;
+    }
+
+    this.phases.update(phases =>
+      phases.map(phase => {
+        if (selected.type === 'phase' && phase.id === selected.phaseId) {
+          return { ...phase, name };
+        }
+
+        if (selected.type === 'subPhase' && phase.id === selected.phaseId) {
+          return {
+            ...phase,
+            subPhases: phase.subPhases.map(sub =>
+              sub.id === selected.subPhaseId ? { ...sub, name } : sub
+            ),
+          };
+        }
+
+        return phase;
+      })
+    );
+  }
+
+  updateSelectedEnd(targetEnd: number): void {
+    const selected = this.selectedNode();
+    if (!selected) {
+      return;
+    }
+
+    this.phases.update(phases =>
+      phases.map(phase => {
+        if (selected.type === 'phase' && phase.id === selected.phaseId) {
+          return { ...phase, targetEnd, successPhaseId: targetEnd };
+        }
+
+        if (selected.type === 'subPhase' && phase.id === selected.phaseId) {
+          return {
+            ...phase,
+            subPhases: phase.subPhases.map(sub =>
+              sub.id === selected.subPhaseId ? { ...sub, targetEnd, successPhaseId: targetEnd } : sub
+            ),
+          };
+        }
+
+        return phase;
+      })
+    );
+  }
+
+  get selectedName(): string {
+    const selected = this.selectedNode();
+    if (!selected) {
+      return '';
+    }
+
+    if (selected.type === 'phase') {
+      return this.phases().find(phase => phase.id === selected.phaseId)?.name ?? '';
+    }
+
+    const parent = this.phases().find(phase => phase.id === selected.phaseId);
+    return parent?.subPhases.find(sub => sub.id === selected.subPhaseId)?.name ?? '';
+  }
+
+  get selectedTargetEnd(): number {
+    const selected = this.selectedNode();
+    if (!selected) {
+      return this.endNodes[0].id;
+    }
+
+    if (selected.type === 'phase') {
+      return this.phases().find(phase => phase.id === selected.phaseId)?.targetEnd ?? this.endNodes[0].id;
+    }
+
+    const parent = this.phases().find(phase => phase.id === selected.phaseId);
+    return (
+      parent?.subPhases.find(sub => sub.id === selected.subPhaseId)?.targetEnd ?? this.endNodes[0].id
+    );
+  }
+
+  get selectedTypeLabel(): string {
+    const selected = this.selectedNode();
+    if (!selected) {
+      return '';
+    }
+
+    return selected.type === 'phase' ? 'Phase' : 'Parallel Phase';
+  }
+
+  getEndPosition(endId: number): { x: number; y: number } | undefined {
+    return this.endPositions().find(end => end.id === endId);
+  }
+
+  downloadJson(): void {
+    const data = this.exportedJson();
+    const blob = new Blob([data], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = 'application-lifecycle.json';
+    anchor.click();
+    URL.revokeObjectURL(url);
+  }
+
+  trackPhase(_: number, phase: PhaseLayoutNode): string {
+    return phase.data.id;
+  }
+
+  trackSubPhase(_: number, sub: PhaseLayoutSubNode): string {
+    return sub.data.id;
+  }
+
+  private createPhase(name: string): SequencePhase {
+    return {
+      id: this.generateId(),
+      name,
+      nodeType: 'phase',
+      value: undefined,
+      lifecycleState: 'InProgress',
+      isEnd: false,
+      failurePhaseId: undefined,
+      successPhaseId: 1,
+      failureButtonText: undefined,
+      successButtonText: undefined,
+      targetEnd: 1,
+      subPhases: [],
+    };
+  }
+
+  private createSubPhase(name: string): SequenceSubPhase {
+    return {
+      id: this.generateId(),
+      name,
+      nodeType: 'parallel',
+      value: undefined,
+      lifecycleState: 'InProgress',
+      isEnd: false,
+      failurePhaseId: undefined,
+      successPhaseId: 1,
+      failureButtonText: undefined,
+      successButtonText: undefined,
+      targetEnd: 1,
+    };
+  }
+
+  private mapPhaseToDto(phase: SequencePhase): ApplicationLifecyclePhaseDto {
+    return {
+      id: phase.id,
+      name: phase.name,
+      value: phase.value,
+      lifecycleState: phase.lifecycleState as ApplicationLifecycleState,
+      isEnd: phase.isEnd,
+      failurePhaseId: phase.failurePhaseId,
+      successPhaseId: phase.targetEnd,
+      failureButtonText: phase.failureButtonText,
+      successButtonText: phase.successButtonText,
+      subPhases: phase.subPhases.map<ApplicationLifecycleSubPhaseDto>(sub => ({
+        id: sub.id,
+        name: sub.name,
+        value: sub.value,
+        lifecycleState: sub.lifecycleState,
+        isEnd: sub.isEnd,
+        failurePhaseId: sub.failurePhaseId,
+        successPhaseId: sub.targetEnd,
+        failureButtonText: sub.failureButtonText,
+        successButtonText: sub.successButtonText,
+      })),
+    };
+  }
+
+  private generateId(): string {
+    this.nextId += 1;
+    return `phase-${this.nextId}`;
+  }
+}

--- a/src/app/models/application-lifecycle-phase.dto.ts
+++ b/src/app/models/application-lifecycle-phase.dto.ts
@@ -1,0 +1,22 @@
+export type ApplicationLifecycleState =
+  | 'NotStarted'
+  | 'InProgress'
+  | 'Completed'
+  | 'Failed'
+  | 'Succeeded';
+
+export interface ApplicationLifecycleSubPhaseDto {
+  id: string;
+  name?: string;
+  value?: number;
+  lifecycleState?: ApplicationLifecycleState;
+  isEnd: boolean;
+  failurePhaseId?: number;
+  successPhaseId?: number;
+  failureButtonText?: string;
+  successButtonText?: string;
+}
+
+export interface ApplicationLifecyclePhaseDto extends ApplicationLifecycleSubPhaseDto {
+  subPhases?: ApplicationLifecycleSubPhaseDto[];
+}

--- a/src/app/pages/sequence-designer/sequence-designer.page.html
+++ b/src/app/pages/sequence-designer/sequence-designer.page.html
@@ -1,0 +1,10 @@
+<div class="sequence-designer-page">
+  <header class="mb-4">
+    <h2 class="h4 mb-1">Application Lifecycle Sequence Designer</h2>
+    <p class="text-muted mb-0">
+      Build your lifecycle phases visually. Add sequential stages, branch into parallel sub-phases, and connect every path to one of the three required end states.
+    </p>
+  </header>
+
+  <app-sequence-diagram-designer></app-sequence-diagram-designer>
+</div>

--- a/src/app/pages/sequence-designer/sequence-designer.page.scss
+++ b/src/app/pages/sequence-designer/sequence-designer.page.scss
@@ -1,0 +1,10 @@
+.sequence-designer-page {
+  padding: 1.5rem;
+  background: #ffffff;
+  border-radius: 1rem;
+  box-shadow: 0 18px 45px rgba(15, 23, 42, 0.06);
+}
+
+header p {
+  max-width: 720px;
+}

--- a/src/app/pages/sequence-designer/sequence-designer.page.ts
+++ b/src/app/pages/sequence-designer/sequence-designer.page.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { SequenceDiagramDesignerComponent } from '../../components/sequence-diagram-designer/sequence-diagram-designer.component';
+
+@Component({
+  selector: 'app-sequence-designer-page',
+  standalone: true,
+  imports: [CommonModule, SequenceDiagramDesignerComponent],
+  templateUrl: './sequence-designer.page.html',
+  styleUrl: './sequence-designer.page.scss',
+})
+export class SequenceDesignerPage {}


### PR DESCRIPTION
## Summary
- add an interactive sequence diagram designer component with signal-based state, SVG rendering, and JSON export
- introduce lifecycle DTO interfaces and a dedicated page to host the designer
- wire the new page into the router and navigation menu

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dff93f2240832c954bd845bf1e5dd1